### PR TITLE
新安装的webpack更新之后很多插件的配置已经不支持，而且webpack.config.js配置也有新的调整

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,18 +21,14 @@
     "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
-    "babel-core": "6.x",
-    "babel-eslint": "6.x",
-    "babel-loader": "6.x",
-    "babel-plugin-import": "^1.0.1",
-    "babel-preset-es2015": "6.x",
-    "babel-preset-react": "6.x",
-    "babel-preset-stage-0": "6.x",
+    "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-react": "^6.22.0",
     "copy-webpack-plugin": "2.x",
     "css-loader": "~0.23.0",
     "es5-shim": "^4.5.8",
     "es6-promise": "^3.2.1",
-    "extract-text-webpack-plugin": "^1.0.1",
+    "extract-text-webpack-plugin": "^2.0.0-beta.4",
     "fetch-ie8": "^1.4.2",
     "file-loader": "^0.9.0",
     "less": "^2.7.1",
@@ -41,8 +37,8 @@
     "open-browser-webpack-plugin": "0.0.2",
     "style-loader": "~0.13.0",
     "url-loader": "^0.5.7",
-    "webpack": "",
-    "webpack-dev-server": ""
+    "webpack": "^2.2.1",
+    "webpack-dev-server": "^2.3.0"
   },
   "keywords": [
     "es6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,6 @@ module.exports = {
         historyApiFallback: true,
         hot: true,
         inline: true,
-        progress: true,
         contentBase: "./app", //最好写上，否则报错，难道这里是一个坑？
         port: 8080
     },
@@ -27,18 +26,18 @@ module.exports = {
     },
     module: {
         loaders: [
-            { test: /\.css$/, loader: ExtractTextPlugin.extract('style', 'css') }, //坑：不能用叹号链接，必须写成这种格式
-            { test: /\.less$/, loader: ExtractTextPlugin.extract('css!less') },
-            { test: /\.js[x]?$/, exclude: /node_modules/, loader: 'babel' },
-            { test: /\.(png|jpg)$/, loader: 'url?limit=8192&name=img/[name].[ext]' },
-            { test: /\.(woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'url' }
+            { test: /\.css$/, loader: ExtractTextPlugin.extract({fallbackLoader:'style-loader', loader:'css-loader'}) }, //坑：不能用叹号链接，必须写成这种格式
+            { test: /\.less$/, loader: ExtractTextPlugin.extract('css-loader!less-loader') },
+            { test: /\.js[x]?$/, exclude: /node_modules/, loader: 'babel-loader' },
+            { test: /\.(png|jpg)$/, loader: 'url-loader?limit=8192&name=img/[name].[ext]' },
+            { test: /\.(woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'url-loader' }
         ]
     },
     resolve: {
-        extensions: ['', '.js', '.jsx'],
+        extensions: [' ', '.js', '.jsx'],
     },
     plugins: [
-        new webpack.optimize.CommonsChunkPlugin('vendors','js/vendors.js'),
+        new webpack.optimize.CommonsChunkPlugin({'name':'vendors','filename':'js/vendors.js'}),
         new ExtractTextPlugin("css/bundle.css"),
         // 如需jquery请解锁
         // new webpack.ProvidePlugin({ $: "jquery" }),

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -14,18 +14,18 @@ module.exports = {
     },
     module: {
         loaders: [
-            { test: /\.css$/, loader: ExtractTextPlugin.extract('style', 'css') }, //坑：不能用叹号链接，必须写成这种格式
-            { test: /\.less$/, loader: ExtractTextPlugin.extract('css!less') },
-            { test: /\.js[x]?$/, exclude: /node_modules/, loader: 'babel' },
-            { test: /\.(png|jpg)$/, loader: 'url?limit=8192&name=img/[name].[ext]' },
-            { test: /\.(woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'url' }
+            { test: /\.css$/, loader: ExtractTextPlugin.extract({fallbackLoader:'style-loader', loader:'css-loader'}) }, //坑：不能用叹号链接，必须写成这种格式
+            { test: /\.less$/, loader: ExtractTextPlugin.extract('css-loader!less-loader') },
+            { test: /\.js[x]?$/, exclude: /node_modules/, loader: 'babel-loader' },
+            { test: /\.(png|jpg)$/, loader: 'url-loader?limit=8192&name=img/[name].[ext]' },
+            { test: /\.(woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'url-loader' }
         ]
     },
     resolve: {
-        extensions: ['', '.js', '.jsx'],
+        extensions: [' ', '.js', '.jsx'],
     },
     plugins: [
-        new webpack.optimize.CommonsChunkPlugin('vendors','js/vendors.js'),
+        new webpack.optimize.CommonsChunkPlugin({'name':'vendors','filename':'js/vendors.js'}),
         new ExtractTextPlugin("css/bundle.css"),
         // jquery配置
         // new webpack.ProvidePlugin({ $: "jquery" }),


### PR DESCRIPTION
作者你好。我看了你的案例，fork你的代码来学习。发现安装的过程中有很多报错，发现是webpack更新到了2.0以上，很多原先的插件都不支持了。我重新修改了配置才能正常运行，所以我将我的修改提交一下，请参考下。谢谢。